### PR TITLE
Added File Checks

### DIFF
--- a/file_processing_ocr/ocr_decorator.py
+++ b/file_processing_ocr/ocr_decorator.py
@@ -12,8 +12,19 @@ try:
     pytesseract.get_tesseract_version()
 except:
     if sys.platform == 'win32':
-        pytesseract.pytesseract.tesseract_cmd = Path('C:/Users') / \
-        getpass.getuser() / 'AppData/Local/Programs/Tesseract-OCR/tesseract.exe'
+        possible_path = [
+            "C:/Program Files/Tesseract-OCR/tesseract.exe",
+            "C:/Program Files (x86)/Tesseract-OCR/tesseract.exe",
+            Path('C:/Users') / getpass.getuser() / 'AppData/Local/Programs/Tesseract-OCR/tesseract.exe'
+        ]
+        found = False
+        for path in possible_path:
+            if os.path.exists(path):
+                pytesseract.pytesseract.tesseract_cmd = path
+                found = True
+                break
+        if not found:
+            TesseractNotFound("Tesseract could not be found or is not installed.")
     elif sys.platform == 'linux':
         pytesseract.pytesseract.tesseract_cmd = '/usr/bin/tesseract'
     else:

--- a/file_processing_ocr/ocr_decorator.py
+++ b/file_processing_ocr/ocr_decorator.py
@@ -24,7 +24,7 @@ except:
                 found = True
                 break
         if not found:
-            TesseractNotFound("Tesseract could not be found or is not installed.")
+            raise TesseractNotFound("Tesseract could not be found or is not installed.")
     elif sys.platform == 'linux':
         pytesseract.pytesseract.tesseract_cmd = '/usr/bin/tesseract'
     else:


### PR DESCRIPTION
So the default path was `C:/Users/{username}/AppData/Local/Programs/Tesseract-OCR/tesseract.exe`, but since tesseract could also be present in the program files I also included that. Now the code check if the executable is present in the folder before setting `pytesseract.pytesseract.tesseract_cmd`